### PR TITLE
Make the README example copy&paste-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The console redirects the standard output and error stream. So by using the `pri
 import at.mukprojects.console.*;
 Console console;
 
-void setup()
+void setup(){
   // Initialize the console 
   console = new Console(this);
   

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The console redirects the standard output and error stream. So by using the `pri
 ## Example
 
 ```java
+import at.mukprojects.console.*;
 Console console;
 
 void setup()


### PR DESCRIPTION
I added the import statement and a missing `{` after `setup()`. Now the code in the README can be taken directly without any changes needed.